### PR TITLE
Fix check for end of header

### DIFF
--- a/ZIF.es6
+++ b/ZIF.es6
@@ -21,8 +21,10 @@ class ZIF {
     if (bytes.long(0) !== 0x08002b4949) throw new Error("invalid zif file");
     let levels = [];
     let ptr = 0x8;
-    while ( ptr > 0 && ptr < ZIF.MAX_HEAD_SIZE) {
+    while (ptr < ZIF.MAX_HEAD_SIZE) {
       ptr = bytes.long(ptr);
+      if (ptr == 0) break;
+      
       let nTags = bytes.long(ptr);
       let level = new ZoomLevel(this.file);
       levels.push(level);


### PR DESCRIPTION
Code as written will never fail the `ptr > 0` test. Zoomify code sets `ptr` before entering loop, and then again at the bottom of the loop; checking after setting will have the same effect.
